### PR TITLE
Change API response content-type

### DIFF
--- a/PyumIpsum.py
+++ b/PyumIpsum.py
@@ -69,7 +69,7 @@ class Subject(Resource):
             data = {'status': "1",
                     'error': dis.error
                     }
-        return Response(json.dumps(data), mimetype='text/json')
+        return Response(json.dumps(data), mimetype='application/json')
 
 
 # Main entry point for the program


### PR DESCRIPTION
Correct mimetype for JSON is "application/json", not "text/json".

Sauce:
- [What is the correct JSON content type?](http://stackoverflow.com/a/477819)
- [Crockford](http://stackoverflow.com/a/2590013)
- [Don't serve JSON as text/html](http://jibbering.com/blog/?p=514)
